### PR TITLE
Switch from 32 bit floats to 64

### DIFF
--- a/src/camera/mod.rs
+++ b/src/camera/mod.rs
@@ -9,7 +9,7 @@ use crate::ray::Ray;
 use image::RgbImage;
 use nalgebra::Vector3;
 use rand::prelude::*;
-use std::f32::consts::PI;
+use std::f64::consts::PI;
 use std::io::{self, Write};
 use std::sync::Arc;
 use std::sync::mpsc::channel;
@@ -20,29 +20,29 @@ pub struct Camera {
     pub image_width: u32,
     pub image_height: u32,
 
-    pub center: Vector3<f32>,
-    pub pixel00_loc: Vector3<f32>,
-    pub pixel_delta_u: Vector3<f32>,
-    pub pixel_delta_v: Vector3<f32>,
+    pub center: Vector3<f64>,
+    pub pixel00_loc: Vector3<f64>,
+    pub pixel_delta_u: Vector3<f64>,
+    pub pixel_delta_v: Vector3<f64>,
     pub samples: u32,
-    pub samples_scale: f32,
+    pub samples_scale: f64,
     pub max_bounces: u32,
     pub threads: usize,
 
-    pub defocus_disk_u: Vector3<f32>,
-    pub defocus_disk_v: Vector3<f32>,
-    pub defocus_angle: f32,
+    pub defocus_disk_u: Vector3<f64>,
+    pub defocus_disk_v: Vector3<f64>,
+    pub defocus_angle: f64,
 
-    pub background: Vector3<f32>,
+    pub background: Vector3<f64>,
 }
 
-fn random_in_unit_disk() -> Vector3<f32> {
+fn random_in_unit_disk() -> Vector3<f64> {
     let mut rng = rand::rng();
 
     loop {
         let p = Vector3::new(
-            rng.random_range(-1.0f32..1.0f32),
-            rng.random_range(-1.0f32..1.0f32),
+            rng.random_range(-1.0f64..1.0f64),
+            rng.random_range(-1.0f64..1.0f64),
             0.0,
         );
         if p.norm_squared() < 1.0 {
@@ -51,7 +51,7 @@ fn random_in_unit_disk() -> Vector3<f32> {
     }
 }
 
-fn linear_to_gamma(linear_component: f32) -> f32 {
+fn linear_to_gamma(linear_component: f64) -> f64 {
     if linear_component > 0.0 {
         linear_component.sqrt()
     } else {
@@ -59,7 +59,7 @@ fn linear_to_gamma(linear_component: f32) -> f32 {
     }
 }
 
-fn degrees_to_radians(degress: f32) -> f32 {
+fn degrees_to_radians(degress: f64) -> f64 {
     degress * PI / 180.0
 }
 
@@ -80,8 +80,8 @@ impl Camera {
         let focus_dist = options.focus_dist;
 
         let h = (theta / 2.0).tan();
-        let viewport_height: f32 = 2.0 * h * focus_dist;
-        let viewport_width: f32 = viewport_height * (image_width as f32 / image_height as f32);
+        let viewport_height: f64 = 2.0 * h * focus_dist;
+        let viewport_width: f64 = viewport_height * (image_width as f64 / image_height as f64);
 
         let w = (look_from - look_at).normalize();
         let u = vup.cross(&w).normalize();
@@ -90,8 +90,8 @@ impl Camera {
         let viewport_u = viewport_width * u;
         let viewport_v = viewport_height * (-v);
 
-        let pixel_delta_u = viewport_u / image_width as f32;
-        let pixel_delta_v = viewport_v / image_height as f32;
+        let pixel_delta_u = viewport_u / image_width as f64;
+        let pixel_delta_v = viewport_v / image_height as f64;
 
         let viewport_upper_left =
             center - (focus_dist * w) - (viewport_u / 2.0) - (viewport_v / 2.0);
@@ -103,7 +103,7 @@ impl Camera {
         let defocus_disk_v = v * defocus_radius;
 
         let samples = options.samples;
-        let samples_scale = 1.0 / (samples as f32);
+        let samples_scale = 1.0 / (samples as f64);
 
         let max_bounces = options.max_bounces;
         let threads = options.threads;
@@ -147,8 +147,8 @@ impl Camera {
         let total = self.image_width * self.image_height;
         let is_tty = atty::is(atty::Stream::Stdout);
         let print_at = match is_tty {
-            true => (total as f32 * 0.01) as usize,
-            false => (total as f32 * 0.05) as usize,
+            true => (total as f64 * 0.01) as usize,
+            false => (total as f64 * 0.05) as usize,
         };
         for (i, (x, y, pixel)) in rx.iter().enumerate() {
             if i % print_at == 0 {
@@ -171,7 +171,7 @@ impl Camera {
     pub fn get_pixel(&self, world: &Geometry, x: u32, y: u32) -> image::Rgb<u8> {
         let color = (0..self.samples)
             .map(|_| self.ray_color(&self.get_ray(x, y), self.max_bounces, world))
-            .sum::<Vector3<f32>>()
+            .sum::<Vector3<f64>>()
             * self.samples_scale;
 
         let intensity = Interval::new(0.0, 0.999);
@@ -183,10 +183,10 @@ impl Camera {
     }
 
     pub fn get_ray(&self, x: u32, y: u32) -> Ray {
-        let offset = math::random_box(-0.5f32..0.5f32);
+        let offset = math::random_box(-0.5f64..0.5f64);
         let pixel_sample = self.pixel00_loc
-            + (self.pixel_delta_u * (offset.x + x as f32))
-            + (self.pixel_delta_v * (offset.y + y as f32));
+            + (self.pixel_delta_u * (offset.x + x as f64))
+            + (self.pixel_delta_v * (offset.y + y as f64));
 
         let ray_origin = match self.defocus_angle <= 0.0 {
             true => self.center,
@@ -195,30 +195,30 @@ impl Camera {
         let ray_direction = pixel_sample - ray_origin;
 
         let mut rng = rand::rng();
-        let t = rng.random_range(0.0f32..1.0f32);
+        let t = rng.random_range(0.0f64..1.0f64);
 
         Ray::new(ray_origin, ray_direction, t)
     }
 
-    pub fn defocus_disk_sample(&self) -> Vector3<f32> {
+    pub fn defocus_disk_sample(&self) -> Vector3<f64> {
         let p = random_in_unit_disk();
         self.center + (p.x * self.defocus_disk_u) + (p.y * self.defocus_disk_v)
     }
 
-    pub fn ray_color(&self, ray: &Ray, depth: u32, world: &Geometry) -> Vector3<f32> {
+    pub fn ray_color(&self, ray: &Ray, depth: u32, world: &Geometry) -> Vector3<f64> {
         if depth == 0 {
             return Vector3::default();
         }
 
         let mut hit_record = HitRecord::default();
-        let interval = Interval::new(0.001, f32::INFINITY);
+        let interval = Interval::new(0.001, f64::INFINITY);
 
         if !world.hit(ray, &interval, &mut hit_record) {
             return self.background;
         }
 
         let mut scattered = Ray::default();
-        let mut attenuation = Vector3::<f32>::default();
+        let mut attenuation = Vector3::<f64>::default();
         let color_from_emission =
             hit_record
                 .material

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -66,7 +66,7 @@ pub enum AspectRatios {
 }
 
 impl AspectRatios {
-    pub fn get_ratio(&self) -> (f32, f32) {
+    pub fn get_ratio(&self) -> (f64, f64) {
         match self {
             AspectRatios::Widescreen => (16.0, 9.0),
             AspectRatios::Square => (1.0, 1.0),
@@ -79,7 +79,7 @@ impl AspectRatios {
     pub fn get_height(&self, width: u32) -> u32 {
         let (ratio_x, ratio_y) = self.get_ratio();
         let ratio = ratio_x / ratio_y;
-        std::cmp::max(1, (width as f32 / ratio) as u32)
+        std::cmp::max(1, (width as f64 / ratio) as u32)
     }
 }
 
@@ -98,19 +98,19 @@ pub struct CameraOptions {
     pub samples: u32,
     pub max_bounces: u32,
     pub threads: usize,
-    pub fov: f32,
+    pub fov: f64,
 
-    pub look_from: [f32; 3],
-    pub look_at: [f32; 3],
-    pub vup: [f32; 3],
+    pub look_from: [f64; 3],
+    pub look_at: [f64; 3],
+    pub vup: [f64; 3],
 
     #[serde_inline_default(0.0)]
-    pub defocus_angle: f32,
+    pub defocus_angle: f64,
     #[serde_inline_default(1.0)]
-    pub focus_dist: f32,
+    pub focus_dist: f64,
 
     #[serde(default)]
-    pub background: [f32; 3],
+    pub background: [f64; 3],
 }
 
 impl CameraOptions {
@@ -126,13 +126,13 @@ impl CameraOptions {
 #[serde(tag = "material", deny_unknown_fields)]
 enum MaterialDef {
     #[serde(rename = "lambertian")]
-    Lambertian { albedo: [f32; 3] },
+    Lambertian { albedo: [f64; 3] },
 
     #[serde(rename = "checkered")]
     Checkered {
-        even: Option<[f32; 3]>,
-        odd: Option<[f32; 3]>,
-        scale: Option<f32>,
+        even: Option<[f64; 3]>,
+        odd: Option<[f64; 3]>,
+        scale: Option<f64>,
     },
 
     #[serde(rename = "texture")]
@@ -140,15 +140,15 @@ enum MaterialDef {
 
     #[serde(rename = "noise")]
     Noise {
-        scale: Option<f32>,
+        scale: Option<f64>,
         turbulance: Option<u32>,
     },
 
     #[serde(rename = "metal")]
-    Metal { albedo: [f32; 3], roughness: f32 },
+    Metal { albedo: [f64; 3], roughness: f64 },
 
     #[serde(rename = "dielectric")]
-    Dielectric { refraction_index: f32 },
+    Dielectric { refraction_index: f64 },
 
     #[serde(rename = "glass")]
     Glass {},
@@ -157,7 +157,7 @@ enum MaterialDef {
     Water {},
 
     #[serde(rename = "light")]
-    Light { emit: [f32; 3] },
+    Light { emit: [f64; 3] },
 }
 
 impl MaterialDef {
@@ -211,12 +211,12 @@ impl MaterialDef {
 
 #[derive(Deserialize)]
 struct RawTranslate {
-    offset: [f32; 3],
+    offset: [f64; 3],
 }
 
 #[derive(Deserialize)]
 struct RawRotate {
-    degrees: f32,
+    degrees: f64,
     axis: Axis,
 }
 
@@ -244,16 +244,16 @@ impl Transform {
 
 #[derive(Deserialize)]
 struct RawVolume {
-    density: f32,
-    albedo: [f32; 3],
+    density: f64,
+    albedo: [f64; 3],
 }
 
 #[derive(Deserialize)]
 struct RawSphere {
     #[serde(rename = "position")]
-    center: [f32; 3],
-    direction: Option<[f32; 3]>,
-    radius: f32,
+    center: [f64; 3],
+    direction: Option<[f64; 3]>,
+    radius: f64,
     #[serde(flatten)]
     material_def: MaterialDef,
     #[serde(default)]
@@ -291,9 +291,9 @@ impl RawSphere {
 
 #[derive(Deserialize)]
 struct RawQuad {
-    position: [f32; 3],
-    u: [f32; 3],
-    v: [f32; 3],
+    position: [f64; 3],
+    u: [f64; 3],
+    v: [f64; 3],
     #[serde(flatten)]
     material_def: MaterialDef,
     #[serde(default)]
@@ -318,8 +318,8 @@ impl RawQuad {
 
 #[derive(Deserialize)]
 struct RawCube {
-    a: [f32; 3],
-    b: [f32; 3],
+    a: [f64; 3],
+    b: [f64; 3],
     #[serde(flatten)]
     material_def: MaterialDef,
     #[serde(default)]

--- a/src/geometry/aabb.rs
+++ b/src/geometry/aabb.rs
@@ -19,7 +19,7 @@ impl Aabb {
         value
     }
 
-    pub fn from_points(a: Vector3<f32>, b: Vector3<f32>) -> Self {
+    pub fn from_points(a: Vector3<f64>, b: Vector3<f64>) -> Self {
         let x = match a.x <= b.x {
             true => Interval::new(a.x, b.x),
             false => Interval::new(b.x, a.x),
@@ -103,7 +103,7 @@ impl Aabb {
         }
     }
 
-    pub fn vertices(&self) -> impl Iterator<Item = Vector3<f32>> {
+    pub fn vertices(&self) -> impl Iterator<Item = Vector3<f64>> {
         iproduct!(
             [self.x.max, self.x.min].into_iter(),
             [self.y.max, self.y.min].into_iter(),
@@ -113,9 +113,9 @@ impl Aabb {
     }
 }
 
-impl Add<Vector3<f32>> for Aabb {
+impl Add<Vector3<f64>> for Aabb {
     type Output = Self;
-    fn add(self, offset: Vector3<f32>) -> Self::Output {
+    fn add(self, offset: Vector3<f64>) -> Self::Output {
         Aabb::new(self.x + offset.x, self.y + offset.y, self.z + offset.z)
     }
 }

--- a/src/geometry/cube.rs
+++ b/src/geometry/cube.rs
@@ -15,9 +15,9 @@ pub struct Cube {
 }
 
 impl Cube {
-    pub fn new(a: Vector3<f32>, b: Vector3<f32>, material: Material) -> Self {
-        let min = Vector3::new(f32::min(a.x, b.x), f32::min(a.y, b.y), f32::min(a.z, b.z));
-        let max = Vector3::new(f32::max(a.x, b.x), f32::max(a.y, b.y), f32::max(a.z, b.z));
+    pub fn new(a: Vector3<f64>, b: Vector3<f64>, material: Material) -> Self {
+        let min = Vector3::new(f64::min(a.x, b.x), f64::min(a.y, b.y), f64::min(a.z, b.z));
+        let max = Vector3::new(f64::max(a.x, b.x), f64::max(a.y, b.y), f64::max(a.z, b.z));
 
         let dx = Vector3::new(max.x - min.x, 0.0, 0.0);
         let dy = Vector3::new(0.0, max.y - min.y, 0.0);
@@ -36,7 +36,7 @@ impl Cube {
 
         Cube { children }
     }
-    pub fn geometry(a: Vector3<f32>, b: Vector3<f32>, material: Material) -> Geometry {
+    pub fn geometry(a: Vector3<f64>, b: Vector3<f64>, material: Material) -> Geometry {
         Geometry::Cube(Cube::new(a, b, material))
     }
 }

--- a/src/geometry/mod.rs
+++ b/src/geometry/mod.rs
@@ -71,17 +71,17 @@ impl Hittable for Geometry {
 }
 
 pub struct HitRecord {
-    pub point: Vector3<f32>,
-    pub normal: Vector3<f32>,
-    pub t: f32,
+    pub point: Vector3<f64>,
+    pub normal: Vector3<f64>,
+    pub t: f64,
     pub front_face: bool,
     pub material: Material,
-    pub u: f32,
-    pub v: f32,
+    pub u: f64,
+    pub v: f64,
 }
 
 impl HitRecord {
-    pub fn set_face_normal(&mut self, r: &Ray, outward_normal: &Vector3<f32>) {
+    pub fn set_face_normal(&mut self, r: &Ray, outward_normal: &Vector3<f64>) {
         self.front_face = r.direction.dot(outward_normal) < 0.0;
         self.normal = if self.front_face {
             *outward_normal

--- a/src/geometry/quad.rs
+++ b/src/geometry/quad.rs
@@ -9,18 +9,18 @@ use nalgebra::Vector3;
 
 #[derive(Debug, Clone)]
 pub struct Quad {
-    pub q: Vector3<f32>,
-    pub u: Vector3<f32>,
-    pub v: Vector3<f32>,
+    pub q: Vector3<f64>,
+    pub u: Vector3<f64>,
+    pub v: Vector3<f64>,
     pub material: Material,
     pub bbox: Aabb,
-    pub normal: Vector3<f32>,
-    pub d: f32,
-    pub w: Vector3<f32>,
+    pub normal: Vector3<f64>,
+    pub d: f64,
+    pub w: Vector3<f64>,
 }
 
 impl Quad {
-    pub fn new(q: Vector3<f32>, u: Vector3<f32>, v: Vector3<f32>, material: Material) -> Self {
+    pub fn new(q: Vector3<f64>, u: Vector3<f64>, v: Vector3<f64>, material: Material) -> Self {
         let n = u.cross(&v);
         let normal = n.normalize();
         let d = normal.dot(&q);
@@ -41,16 +41,16 @@ impl Quad {
         }
     }
     pub fn geomtry(
-        q: Vector3<f32>,
-        u: Vector3<f32>,
-        v: Vector3<f32>,
+        q: Vector3<f64>,
+        u: Vector3<f64>,
+        v: Vector3<f64>,
         material: Material,
     ) -> Geometry {
         Geometry::Quad(Quad::new(q, u, v, material))
     }
 }
 
-fn is_interior(a: f32, b: f32, record: &mut HitRecord) -> bool {
+fn is_interior(a: f64, b: f64, record: &mut HitRecord) -> bool {
     let unit_interval = Interval::new(0.0, 1.0);
 
     if !unit_interval.contains(a) || !unit_interval.contains(b) {

--- a/src/geometry/rotate.rs
+++ b/src/geometry/rotate.rs
@@ -11,13 +11,13 @@ use nalgebra::Vector3;
 #[derive(Debug, Clone)]
 pub struct Rotate {
     geometry: Box<Geometry>,
-    rotation: Rotation3<f32>,
+    rotation: Rotation3<f64>,
     bbox: Aabb,
 }
 
 impl Rotate {
-    pub fn new(geometry: Geometry, axis: Axis, angle: f32) -> Self {
-        let rotation: Rotation3<f32> = Rotation3::from_axis_angle(
+    pub fn new(geometry: Geometry, axis: Axis, angle: f64) -> Self {
+        let rotation: Rotation3<f64> = Rotation3::from_axis_angle(
             &match axis {
                 Axis::X => Vector3::x_axis(),
                 Axis::Y => Vector3::y_axis(),
@@ -26,18 +26,18 @@ impl Rotate {
             angle.to_radians(),
         );
 
-        let rotated_vertices: Vec<Vector3<f32>> = geometry
+        let rotated_vertices: Vec<Vector3<f64>> = geometry
             .bounding_box()
             .vertices()
             .map(|vertex| rotation * vertex)
             .collect();
 
         let min = rotated_vertices.iter().fold(
-            Vector3::new(f32::INFINITY, f32::INFINITY, f32::INFINITY),
+            Vector3::new(f64::INFINITY, f64::INFINITY, f64::INFINITY),
             |culm, vert| culm.inf(vert),
         );
         let max = rotated_vertices.iter().fold(
-            Vector3::new(f32::NEG_INFINITY, f32::NEG_INFINITY, f32::NEG_INFINITY),
+            Vector3::new(f64::NEG_INFINITY, f64::NEG_INFINITY, f64::NEG_INFINITY),
             |culm, vert| culm.sup(vert),
         );
 
@@ -50,7 +50,7 @@ impl Rotate {
             bbox,
         }
     }
-    pub fn geometry(geometry: Geometry, axis: Axis, angle: f32) -> Geometry {
+    pub fn geometry(geometry: Geometry, axis: Axis, angle: f64) -> Geometry {
         Geometry::Rotate(Rotate::new(geometry, axis, angle))
     }
 }

--- a/src/geometry/sphere.rs
+++ b/src/geometry/sphere.rs
@@ -6,17 +6,17 @@ use crate::interval::Interval;
 use crate::material::Material;
 use crate::ray::Ray;
 use nalgebra::Vector3;
-use std::f32::consts::PI;
+use std::f64::consts::PI;
 
 #[derive(Debug, Clone)]
 pub struct Sphere {
     pub center: Ray,
-    pub radius: f32,
+    pub radius: f64,
     pub material: Material,
     pub bbox: Aabb,
 }
 
-pub fn get_sphere_uv(point: Vector3<f32>) -> (f32, f32) {
+pub fn get_sphere_uv(point: Vector3<f64>) -> (f64, f64) {
     let theta = point.y.acos();
     let phi = (-point.z).atan2(point.x) + PI;
 
@@ -25,9 +25,9 @@ pub fn get_sphere_uv(point: Vector3<f32>) -> (f32, f32) {
 
 impl Sphere {
     pub fn new(
-        center: Vector3<f32>,
-        direction: Vector3<f32>,
-        radius: f32,
+        center: Vector3<f64>,
+        direction: Vector3<f64>,
+        radius: f64,
         material: Material,
     ) -> Sphere {
         let center = Ray::new(center, direction, 0.0);
@@ -45,9 +45,9 @@ impl Sphere {
     }
 
     pub fn geometry(
-        center: Vector3<f32>,
-        direction: Vector3<f32>,
-        radius: f32,
+        center: Vector3<f64>,
+        direction: Vector3<f64>,
+        radius: f64,
         material: Material,
     ) -> Geometry {
         Geometry::Sphere(Sphere::new(center, direction, radius, material))

--- a/src/geometry/translate.rs
+++ b/src/geometry/translate.rs
@@ -9,12 +9,12 @@ use nalgebra::Vector3;
 #[derive(Debug, Clone)]
 pub struct Translate {
     geometry: Box<Geometry>,
-    offset: Vector3<f32>,
+    offset: Vector3<f64>,
     bbox: Aabb,
 }
 
 impl Translate {
-    pub fn new(geometry: Geometry, offset: Vector3<f32>) -> Self {
+    pub fn new(geometry: Geometry, offset: Vector3<f64>) -> Self {
         let geometry = Box::new(geometry);
         let bbox = geometry.bounding_box() + offset;
         Translate {
@@ -23,7 +23,7 @@ impl Translate {
             bbox,
         }
     }
-    pub fn geometry(geometry: Geometry, offset: Vector3<f32>) -> Geometry {
+    pub fn geometry(geometry: Geometry, offset: Vector3<f64>) -> Geometry {
         Geometry::Translate(Translate::new(geometry, offset))
     }
 }

--- a/src/geometry/volume.rs
+++ b/src/geometry/volume.rs
@@ -13,12 +13,12 @@ use rand::prelude::*;
 #[derive(Debug, Clone)]
 pub struct Volume {
     boundry: Box<Geometry>,
-    neg_inv_density: f32,
+    neg_inv_density: f64,
     phase_function: Material,
 }
 
 impl Volume {
-    pub fn new(boundry: Geometry, density: f32, texture: Texture) -> Self {
+    pub fn new(boundry: Geometry, density: f64, texture: Texture) -> Self {
         let boundry = Box::new(boundry);
         let neg_inv_density = -1.0 / density;
         let phase_function = Isotropic::material(texture);
@@ -28,7 +28,7 @@ impl Volume {
             phase_function,
         }
     }
-    pub fn geometry(boundry: Geometry, density: f32, texture: Texture) -> Geometry {
+    pub fn geometry(boundry: Geometry, density: f64, texture: Texture) -> Geometry {
         Geometry::Volume(Volume::new(boundry, density, texture))
     }
 }
@@ -44,7 +44,7 @@ impl Hittable for Volume {
 
         if !self.boundry.hit(
             r,
-            &Interval::new(record_a.t + 0.0001, f32::INFINITY),
+            &Interval::new(record_a.t + 0.0001, f64::INFINITY),
             &mut record_b,
         ) {
             return false;
@@ -69,7 +69,7 @@ impl Hittable for Volume {
         let ray_length = r.direction.norm();
         let distance_inside_boundary = (record_b.t - record_a.t) * ray_length;
         let mut rng = rand::rng();
-        let random_double = rng.random_range(0.0f32..1.0f32);
+        let random_double = rng.random_range(0.0f64..1.0f64);
         let hit_distance = self.neg_inv_density * random_double.ln();
 
         if hit_distance > distance_inside_boundary {

--- a/src/interval/mod.rs
+++ b/src/interval/mod.rs
@@ -1,20 +1,20 @@
-use core::f32;
+use core::f64;
 use std::ops::Add;
 
 #[derive(Debug, Clone, Copy)]
 pub struct Interval {
-    pub min: f32,
-    pub max: f32,
+    pub min: f64,
+    pub max: f64,
 }
 
 impl Interval {
-    pub fn new(min: f32, max: f32) -> Self {
+    pub fn new(min: f64, max: f64) -> Self {
         Self { min, max }
     }
 
     pub fn universe() -> Self {
-        let min = f32::NEG_INFINITY;
-        let max = f32::INFINITY;
+        let min = f64::NEG_INFINITY;
+        let max = f64::INFINITY;
         Interval { min, max }
     }
 
@@ -24,11 +24,11 @@ impl Interval {
         Interval { min, max }
     }
 
-    pub fn size(&self) -> f32 {
+    pub fn size(&self) -> f64 {
         self.max - self.min
     }
 
-    pub fn expand(&self, delta: f32) -> Self {
+    pub fn expand(&self, delta: f64) -> Self {
         let padding = delta / 2.0;
         Interval {
             min: self.min - padding,
@@ -36,11 +36,11 @@ impl Interval {
         }
     }
 
-    pub fn contains(&self, x: f32) -> bool {
+    pub fn contains(&self, x: f64) -> bool {
         self.min <= x && x <= self.max
     }
 
-    pub fn clamp(&self, value: f32) -> f32 {
+    pub fn clamp(&self, value: f64) -> f64 {
         if value < self.min {
             self.min
         } else if value > self.max {
@@ -50,15 +50,15 @@ impl Interval {
         }
     }
 
-    pub fn surrounds(&self, value: f32) -> bool {
+    pub fn surrounds(&self, value: f64) -> bool {
         value > self.min && value < self.max
     }
 }
 
 impl Default for Interval {
     fn default() -> Self {
-        let min = f32::INFINITY;
-        let max = f32::NEG_INFINITY;
+        let min = f64::INFINITY;
+        let max = f64::NEG_INFINITY;
         Interval { min, max }
     }
 }
@@ -81,9 +81,9 @@ impl PartialOrd for Interval {
     }
 }
 
-impl Add<f32> for Interval {
+impl Add<f64> for Interval {
     type Output = Self;
-    fn add(self, offset: f32) -> Self::Output {
+    fn add(self, offset: f64) -> Self::Output {
         Interval {
             min: self.min + offset,
             max: self.max + offset,

--- a/src/material/dielectric.rs
+++ b/src/material/dielectric.rs
@@ -11,11 +11,11 @@ use std::fmt::Debug;
 
 #[derive(Debug, Clone)]
 pub struct Dielectric {
-    pub refraction_index: f32,
+    pub refraction_index: f64,
 }
 
 impl Dielectric {
-    pub fn material(refraction_index: f32) -> Material {
+    pub fn material(refraction_index: f64) -> Material {
         Material::Dielectric(Dielectric { refraction_index })
     }
 }
@@ -25,7 +25,7 @@ impl Surface for Dielectric {
         &self,
         r_in: &Ray,
         record: &HitRecord,
-        attenuation: &mut Vector3<f32>,
+        attenuation: &mut Vector3<f64>,
         scattered: &mut Ray,
     ) -> bool {
         attenuation.copy_from(&Vector3::from_element(1.0));
@@ -36,14 +36,14 @@ impl Surface for Dielectric {
 
         let normalized_direction = r_in.direction.normalize();
 
-        let cos_theta = f32::min((-normalized_direction).dot(&record.normal), 1.0);
+        let cos_theta = f64::min((-normalized_direction).dot(&record.normal), 1.0);
         let sin_theta = (1.0 - cos_theta * cos_theta).sqrt();
         let cannot_refract = r_index * sin_theta > 1.0;
 
         scattered.origin = record.point;
         scattered.time = r_in.time;
         let mut rng = rand::rng();
-        let random = rng.random_range(0.0f32..1.0f32);
+        let random = rng.random_range(0.0f64..1.0f64);
 
         scattered.direction = match cannot_refract || (reflectance(cos_theta, r_index) > random) {
             true => reflect(&normalized_direction, &record.normal),
@@ -53,7 +53,7 @@ impl Surface for Dielectric {
         true
     }
 
-    fn emitted(&self, _: f32, _: f32, _: Vector3<f32>) -> Vector3<f32> {
-        Vector3::<f32>::default()
+    fn emitted(&self, _: f64, _: f64, _: Vector3<f64>) -> Vector3<f64> {
+        Vector3::<f64>::default()
     }
 }

--- a/src/material/isotropic.rs
+++ b/src/material/isotropic.rs
@@ -27,7 +27,7 @@ impl Surface for Isotropic {
         &self,
         r_in: &Ray,
         record: &HitRecord,
-        attenuation: &mut Vector3<f32>,
+        attenuation: &mut Vector3<f64>,
         scattered: &mut Ray,
     ) -> bool {
         scattered.origin = record.point;
@@ -37,7 +37,7 @@ impl Surface for Isotropic {
         true
     }
 
-    fn emitted(&self, _: f32, _: f32, _: Vector3<f32>) -> Vector3<f32> {
-        Vector3::<f32>::default()
+    fn emitted(&self, _: f64, _: f64, _: Vector3<f64>) -> Vector3<f64> {
+        Vector3::<f64>::default()
     }
 }

--- a/src/material/lambertian.rs
+++ b/src/material/lambertian.rs
@@ -25,7 +25,7 @@ impl Surface for Lambertian {
         &self,
         r_in: &Ray,
         record: &HitRecord,
-        attenuation: &mut Vector3<f32>,
+        attenuation: &mut Vector3<f64>,
         scattered: &mut Ray,
     ) -> bool {
         let mut scatter_direction = record.normal + math::random_normal();
@@ -40,7 +40,7 @@ impl Surface for Lambertian {
         true
     }
 
-    fn emitted(&self, _: f32, _: f32, _: Vector3<f32>) -> Vector3<f32> {
-        Vector3::<f32>::default()
+    fn emitted(&self, _: f64, _: f64, _: Vector3<f64>) -> Vector3<f64> {
+        Vector3::<f64>::default()
     }
 }

--- a/src/material/light.rs
+++ b/src/material/light.rs
@@ -19,11 +19,11 @@ impl Light {
 }
 
 impl Surface for Light {
-    fn scatter(&self, _: &Ray, _: &HitRecord, _: &mut Vector3<f32>, _: &mut Ray) -> bool {
+    fn scatter(&self, _: &Ray, _: &HitRecord, _: &mut Vector3<f64>, _: &mut Ray) -> bool {
         false
     }
 
-    fn emitted(&self, u: f32, v: f32, p: Vector3<f32>) -> Vector3<f32> {
+    fn emitted(&self, u: f64, v: f64, p: Vector3<f64>) -> Vector3<f64> {
         self.texture.sample(u, v, p)
     }
 }

--- a/src/material/metal.rs
+++ b/src/material/metal.rs
@@ -9,12 +9,12 @@ use std::fmt::Debug;
 
 #[derive(Debug, Clone)]
 pub struct Metal {
-    pub albedo: Vector3<f32>,
-    pub roughness: f32,
+    pub albedo: Vector3<f64>,
+    pub roughness: f64,
 }
 
 impl Metal {
-    pub fn material(albedo: Vector3<f32>, roughness: f32) -> Material {
+    pub fn material(albedo: Vector3<f64>, roughness: f64) -> Material {
         Material::Metal(Metal { albedo, roughness })
     }
 }
@@ -24,7 +24,7 @@ impl Surface for Metal {
         &self,
         r_in: &Ray,
         record: &HitRecord,
-        attenuation: &mut Vector3<f32>,
+        attenuation: &mut Vector3<f64>,
         scattered: &mut Ray,
     ) -> bool {
         let mut reflected = reflect(&r_in.direction, &record.normal);
@@ -37,7 +37,7 @@ impl Surface for Metal {
         scattered.direction.dot(&record.normal) > 0.0
     }
 
-    fn emitted(&self, _: f32, _: f32, _: Vector3<f32>) -> Vector3<f32> {
-        Vector3::<f32>::default()
+    fn emitted(&self, _: f64, _: f64, _: Vector3<f64>) -> Vector3<f64> {
+        Vector3::<f64>::default()
     }
 }

--- a/src/material/mod.rs
+++ b/src/material/mod.rs
@@ -20,10 +20,10 @@ pub trait Surface {
         &self,
         ray_in: &Ray,
         record: &HitRecord,
-        attenuation: &mut Vector3<f32>,
+        attenuation: &mut Vector3<f64>,
         scattered: &mut Ray,
     ) -> bool;
-    fn emitted(&self, u: f32, v: f32, p: Vector3<f32>) -> Vector3<f32>;
+    fn emitted(&self, u: f64, v: f64, p: Vector3<f64>) -> Vector3<f64>;
 }
 
 #[derive(Debug, Clone)]
@@ -40,7 +40,7 @@ impl Surface for Material {
         &self,
         ray_in: &Ray,
         record: &HitRecord,
-        attenuation: &mut Vector3<f32>,
+        attenuation: &mut Vector3<f64>,
         scattered: &mut Ray,
     ) -> bool {
         match self {
@@ -57,7 +57,7 @@ impl Surface for Material {
             }
         }
     }
-    fn emitted(&self, u: f32, v: f32, p: Vector3<f32>) -> Vector3<f32> {
+    fn emitted(&self, u: f64, v: f64, p: Vector3<f64>) -> Vector3<f64> {
         match self {
             Material::Metal(material) => material.emitted(u, v, p),
             Material::Dielectric(material) => material.emitted(u, v, p),

--- a/src/material/texture.rs
+++ b/src/material/texture.rs
@@ -6,7 +6,7 @@ use std::fmt::Debug;
 use std::sync::Arc;
 
 pub trait Sample {
-    fn sample(&self, u: f32, v: f32, p: Vector3<f32>) -> Vector3<f32>;
+    fn sample(&self, u: f64, v: f64, p: Vector3<f64>) -> Vector3<f64>;
 }
 
 #[derive(Debug, Clone)]
@@ -18,7 +18,7 @@ pub enum Texture {
 }
 
 impl Sample for Texture {
-    fn sample(&self, u: f32, v: f32, p: Vector3<f32>) -> Vector3<f32> {
+    fn sample(&self, u: f64, v: f64, p: Vector3<f64>) -> Vector3<f64> {
         match self {
             Texture::SolidColor(texture) => texture.sample(u, v, p),
             Texture::Checkered(texture) => texture.sample(u, v, p),
@@ -30,37 +30,37 @@ impl Sample for Texture {
 
 #[derive(Debug, Clone)]
 pub struct SolidColor {
-    pub albedo: Vector3<f32>,
+    pub albedo: Vector3<f64>,
 }
 
 impl SolidColor {
-    pub fn texture(albedo: Vector3<f32>) -> Texture {
+    pub fn texture(albedo: Vector3<f64>) -> Texture {
         Texture::SolidColor(SolidColor { albedo })
     }
 }
 
 impl Sample for SolidColor {
-    fn sample(&self, _: f32, _: f32, _: Vector3<f32>) -> Vector3<f32> {
+    fn sample(&self, _: f64, _: f64, _: Vector3<f64>) -> Vector3<f64> {
         self.albedo
     }
 }
 
 #[derive(Debug, Clone)]
 pub struct Checkered {
-    pub even: Vector3<f32>,
-    pub odd: Vector3<f32>,
-    pub scale: f32,
+    pub even: Vector3<f64>,
+    pub odd: Vector3<f64>,
+    pub scale: f64,
 }
 
 impl Checkered {
-    pub fn texture(scale: f32, even: Vector3<f32>, odd: Vector3<f32>) -> Texture {
+    pub fn texture(scale: f64, even: Vector3<f64>, odd: Vector3<f64>) -> Texture {
         let scale = 1.0 / scale;
         Texture::Checkered(Checkered { scale, even, odd })
     }
 }
 
 impl Sample for Checkered {
-    fn sample(&self, _: f32, _: f32, p: Vector3<f32>) -> Vector3<f32> {
+    fn sample(&self, _: f64, _: f64, p: Vector3<f64>) -> Vector3<f64> {
         let x_int = (p.x * self.scale).floor() as i32;
         let y_int = (p.y * self.scale).floor() as i32;
         let z_int = (p.z * self.scale).floor() as i32;
@@ -85,31 +85,31 @@ impl Image {
 }
 
 impl Sample for Image {
-    fn sample(&self, u: f32, v: f32, _: Vector3<f32>) -> Vector3<f32> {
+    fn sample(&self, u: f64, v: f64, _: Vector3<f64>) -> Vector3<f64> {
         let interval = Interval::new(0.0, 1.0);
 
         let u = interval.clamp(u);
         let v = interval.clamp(v);
 
-        let i = (u * self.data.width() as f32) as u32;
-        let j = (v * self.data.height() as f32) as u32;
+        let i = (u * self.data.width() as f64) as u32;
+        let j = (v * self.data.height() as f64) as u32;
 
         let pixel = self.data.get_pixel(i, j);
         let color_scale = 1.0 / 256.0;
 
-        Vector3::new(pixel[0] as f32, pixel[1] as f32, pixel[2] as f32) * color_scale
+        Vector3::new(pixel[0] as f64, pixel[1] as f64, pixel[2] as f64) * color_scale
     }
 }
 
 #[derive(Debug, Clone)]
 pub struct Noise {
     pub perlin: Perlin,
-    pub scale: f32,
+    pub scale: f64,
     pub turbulance: u32,
 }
 
 impl Noise {
-    pub fn texture(scale: f32, turbulance: u32) -> Texture {
+    pub fn texture(scale: f64, turbulance: u32) -> Texture {
         let perlin = Perlin::default();
         Texture::Noise(Noise {
             perlin,
@@ -120,7 +120,7 @@ impl Noise {
 }
 
 impl Sample for Noise {
-    fn sample(&self, _: f32, _: f32, p: Vector3<f32>) -> Vector3<f32> {
-        Vector3::from_element(1.0f32) * (self.perlin.turb(p * self.scale, self.turbulance))
+    fn sample(&self, _: f64, _: f64, p: Vector3<f64>) -> Vector3<f64> {
+        Vector3::from_element(1.0f64) * (self.perlin.turb(p * self.scale, self.turbulance))
     }
 }

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -2,7 +2,7 @@ use nalgebra::Vector3;
 use rand::prelude::*;
 use std::ops::Range;
 
-pub fn random(range: Range<f32>) -> Vector3<f32> {
+pub fn random(range: Range<f64>) -> Vector3<f64> {
     let mut rng = rand::rng();
     Vector3::new(
         rng.random_range(range.clone()),
@@ -11,7 +11,7 @@ pub fn random(range: Range<f32>) -> Vector3<f32> {
     )
 }
 
-pub fn random_box(range: Range<f32>) -> Vector3<f32> {
+pub fn random_box(range: Range<f64>) -> Vector3<f64> {
     let mut rng = rand::rng();
     Vector3::new(
         rng.random_range(range.clone()),
@@ -20,32 +20,32 @@ pub fn random_box(range: Range<f32>) -> Vector3<f32> {
     )
 }
 
-pub fn random_normal() -> Vector3<f32> {
+pub fn random_normal() -> Vector3<f64> {
     loop {
-        let position = random(-1.0f32..1.0f32);
+        let position = random(-1.0f64..1.0f64);
         let lensq = position.norm_squared();
-        if f32::EPSILON < lensq && lensq <= 1.0 {
+        if f64::EPSILON < lensq && lensq <= 1.0 {
             return position / lensq.sqrt();
         }
     }
 }
 
-pub fn near_zero(v: &Vector3<f32>) -> bool {
+pub fn near_zero(v: &Vector3<f64>) -> bool {
     v.x.abs() < 1e-8 && v.y.abs() < 1e-8 && v.z.abs() < 1e-8
 }
 
-pub fn reflect(a: &Vector3<f32>, n: &Vector3<f32>) -> Vector3<f32> {
+pub fn reflect(a: &Vector3<f64>, n: &Vector3<f64>) -> Vector3<f64> {
     a - n * (a.dot(n) * 2.0)
 }
 
-pub fn refract(uv: &Vector3<f32>, n: &Vector3<f32>, etai_over_etat: f32) -> Vector3<f32> {
-    let cos_theta = f32::min((-uv).dot(n), 1.0);
+pub fn refract(uv: &Vector3<f64>, n: &Vector3<f64>, etai_over_etat: f64) -> Vector3<f64> {
+    let cos_theta = f64::min((-uv).dot(n), 1.0);
     let r_out_perp = etai_over_etat * (uv + cos_theta * n);
     let r_out_parallel = -((1.0 - r_out_perp.norm_squared()).abs()).sqrt() * n;
     r_out_perp + r_out_parallel
 }
 
-pub fn reflectance(cosine: f32, refraction_index: f32) -> f32 {
+pub fn reflectance(cosine: f64, refraction_index: f64) -> f64 {
     let r0 = (1.0 - refraction_index) / (1.0 + refraction_index);
     let r1 = r0 * r0;
     r1 + (1.0 - r1) * (1.0 - cosine).powf(5.0)

--- a/src/noise/mod.rs
+++ b/src/noise/mod.rs
@@ -6,7 +6,7 @@ const PERLIN_POINT_COUNT: usize = 256;
 
 #[derive(Debug, Clone)]
 pub struct Perlin {
-    randvec: Box<[Vector3<f32>; PERLIN_POINT_COUNT]>,
+    randvec: Box<[Vector3<f64>; PERLIN_POINT_COUNT]>,
     perm_x: Box<[usize; PERLIN_POINT_COUNT]>,
     perm_y: Box<[usize; PERLIN_POINT_COUNT]>,
     perm_z: Box<[usize; PERLIN_POINT_COUNT]>,
@@ -21,12 +21,12 @@ impl Default for Perlin {
 impl Perlin {
     pub fn new() -> Self {
         let mut rng = rand::rng();
-        let mut randvec = [Vector3::<f32>::default(); PERLIN_POINT_COUNT];
+        let mut randvec = [Vector3::<f64>::default(); PERLIN_POINT_COUNT];
         for vec in randvec.iter_mut() {
             *vec = Vector3::new(
-                rng.random_range(-1.0f32..1.0f32),
-                rng.random_range(-1.0f32..1.0f32),
-                rng.random_range(-1.0f32..1.0f32),
+                rng.random_range(-1.0f64..1.0f64),
+                rng.random_range(-1.0f64..1.0f64),
+                rng.random_range(-1.0f64..1.0f64),
             )
             .normalize();
         }
@@ -48,7 +48,7 @@ impl Perlin {
         }
     }
 
-    pub fn noise(&self, point: Vector3<f32>) -> f32 {
+    pub fn noise(&self, point: Vector3<f64>) -> f64 {
         let u = point.x - point.x.floor();
         let v = point.y - point.y.floor();
         let w = point.z - point.z.floor();
@@ -56,7 +56,7 @@ impl Perlin {
         let i = (point.x.floor()) as i32;
         let j = (point.y.floor()) as i32;
         let k = (point.z.floor()) as i32;
-        let mut c = [[[Vector3::<f32>::default(); 2]; 2]; 2];
+        let mut c = [[[Vector3::<f64>::default(); 2]; 2]; 2];
 
         iproduct!(0..2, 0..2, 0..2).for_each(|(di, dj, dk)| {
             let xi = ((i + di) & 255) as usize;
@@ -79,7 +79,7 @@ impl Perlin {
         (1..n).rev().for_each(|i| p.swap(i, rng.random_range(0..i)));
     }
 
-    pub fn turb(&self, point: Vector3<f32>, depth: u32) -> f32 {
+    pub fn turb(&self, point: Vector3<f64>, depth: u32) -> f64 {
         let mut temp_p = point;
         let mut weight = 1.0;
         (0..depth)
@@ -89,22 +89,22 @@ impl Perlin {
                 temp_p *= 2.0;
                 val
             })
-            .sum::<f32>()
+            .sum::<f64>()
             .abs()
     }
 
-    pub fn perlin_interp(c: &[[[Vector3<f32>; 2]; 2]; 2], u: f32, v: f32, w: f32) -> f32 {
+    pub fn perlin_interp(c: &[[[Vector3<f64>; 2]; 2]; 2], u: f64, v: f64, w: f64) -> f64 {
         let uu = u * u * (3.0 - 2.0 * u);
         let vv = v * v * (3.0 - 2.0 * v);
         let ww = w * w * (3.0 - 2.0 * w);
 
         iproduct!(0..2, 0..2, 0..2)
             .map(|(i, j, k)| {
-                let fi = i as f32;
-                let ji = j as f32;
-                let ki = k as f32;
+                let fi = i as f64;
+                let ji = j as f64;
+                let ki = k as f64;
 
-                let weight_v = Vector3::<f32>::new(u - fi, v - ji, w - ki);
+                let weight_v = Vector3::<f64>::new(u - fi, v - ji, w - ki);
 
                 (fi * uu + (1.0 - fi) * (1.0 - uu))
                     * (ji * vv + (1.0 - ji) * (1.0 - vv))

--- a/src/ray/mod.rs
+++ b/src/ray/mod.rs
@@ -2,13 +2,13 @@ use nalgebra::Vector3;
 
 #[derive(Debug, Clone, Copy, Default)]
 pub struct Ray {
-    pub origin: Vector3<f32>,
-    pub direction: Vector3<f32>,
-    pub time: f32,
+    pub origin: Vector3<f64>,
+    pub direction: Vector3<f64>,
+    pub time: f64,
 }
 
 impl Ray {
-    pub fn new(origin: Vector3<f32>, direction: Vector3<f32>, time: f32) -> Self {
+    pub fn new(origin: Vector3<f64>, direction: Vector3<f64>, time: f64) -> Self {
         Ray {
             origin,
             direction,
@@ -16,7 +16,7 @@ impl Ray {
         }
     }
 
-    pub fn at(&self, time: f32) -> Vector3<f32> {
+    pub fn at(&self, time: f64) -> Vector3<f64> {
         self.origin + self.direction * time
     }
 }


### PR DESCRIPTION
## What

Switch from 32 bit floats to 64 for better precision and accuracy of renders. (I noticed with 32 bit floats I was getting visual artifacts with longer distance scenes)